### PR TITLE
Added support for real APIs and dev mode to avoid using them using .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_CUSTOM_DEV_MODE=false

--- a/src/backend/model/events.ts
+++ b/src/backend/model/events.ts
@@ -1,46 +1,47 @@
 import axios from "axios";
 import type {newsFeedDataInterface} from "./interfaces.ts";
 
+const isDevMode = import.meta.env.VITE_CUSTOM_DEV_MODE === "true";
+
 const loadNewsFeedData = async () => {
-    /*
-    // TODO - Replace 'const EVENTS_URL' with the code below to account for rate-limiting. This SHOULD be safe to change, but check first.
     const BACKUP_EVENTS_URL = `https://lldev.thespacedevs.com/2.3.0/events/?limit=3&?ordering=-last_updated`; // Backup development API with no rate-limiting
     const REAL_EVENTS_URL = `https://ll.thespacedevs.com/2.3.0/events/?limit=3&?ordering=-last_updated`; // Real API with rate-limiting
-    try {
-        let response = await axios.get(REAL_EVENTS_URL);
-        if (response.status != 200) {
-            // if the response HTTP status is not 200 ("Success"), call the backup API.
+    let response;
+
+    if (isDevMode) {
+        // If we're in dev mode, skip calling the real API.
+        response = await axios.get(BACKUP_EVENTS_URL);
+    } else {
+        try {
+            response = await axios.get(REAL_EVENTS_URL);
+        } catch (error) {
+            console.warn("Failed to load from LL2 Events (news feed) API. Falling back to dev/backup API.", error);
             response = await axios.get(BACKUP_EVENTS_URL);
         }
-    */
-    const EVENTS_URL = `https://lldev.thespacedevs.com/2.3.0/events/?limit=3&?ordering=-last_updated`;
-    try {
-        let response = await axios.get(EVENTS_URL);
-        return response.data.results.map((event: any) => {
-            let URL;
-
-            if (event.vid_urls.length != 0) {
-                URL = event.vid_urls[0];
-            } else if (event.info_urls.length != 0) {
-                URL = event.info_urls[0];
-            } else {
-                URL = null;
-            }
-
-            let eventObject: newsFeedDataInterface = {
-                bodyText: event.description,
-                date: event.date,
-                eventType: event.type.name,
-                headline: event.name,
-                imageURL: event.image.image_url,
-                sourceURL: URL
-            };
-            // todo - filter data like in launches.ts
-            return eventObject;
-        });
-    } catch (error) {
-        console.error('Error fetching events', error);
     }
+
+    return response.data.results.map((event: any) => {
+        let URL;
+
+        if (event.vid_urls.length != 0) {
+            URL = event.vid_urls[0];
+        } else if (event.info_urls.length != 0) {
+            URL = event.info_urls[0];
+        } else {
+            URL = null;
+        }
+
+        let eventObject: newsFeedDataInterface = {
+            bodyText: event.description,
+            date: event.date,
+            eventType: event.type.name,
+            headline: event.name,
+            imageURL: event.image.image_url,
+            sourceURL: URL
+        };
+        // todo - filter data like in launches.ts
+        return eventObject;
+    });
 }
 
 export {loadNewsFeedData}

--- a/src/backend/model/satellites.ts
+++ b/src/backend/model/satellites.ts
@@ -2,7 +2,9 @@
 import axios from "axios";
 import type {satelliteTLEInterface} from "./interfaces.ts";
 import * as satellite from "satellite.js";
-import celestrak from "../../example-jsons/celestrak.json"
+import celestrakExampleJSON from "../../example-jsons/celestrak.json"
+
+const isDevMode = import.meta.env.VITE_CUSTOM_DEV_MODE === "true";
 
 export function parseRawTLEStringIntoTLEObjectArray(
     rawTLEString: string
@@ -28,23 +30,25 @@ export function parseRawTLEStringIntoTLEObjectArray(
 }
 
 export const load100BrightestSatellites = async (): Promise<satelliteTLEInterface[]> => {
-    /*
-    // Real API Call
     const CELESTRAK_URL = "https://www.celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=tle";
-    try {
-        const response = await axios.get(CELESTRAK_URL);
-        if (response.status !== 200) {
-            console.error("Celestrak did not send an HTTP 200 code.");
-        }
-        const parsedTLEObjectArray = parseRawTLEStringIntoTLEObjectArray(
-            response.data
-        );
+    const exampleDataFromJSON = celestrakExampleJSON[0].data;
+    if (isDevMode) {
+        // If we're in dev mode, skip calling the real API.
+        console.log("devmode!")
+        return parseRawTLEStringIntoTLEObjectArray(exampleDataFromJSON);
+    } else {
+        let parsedTLEObjectArray: satelliteTLEInterface[];
+        try {
+            const response = await axios.get(CELESTRAK_URL);
+            parsedTLEObjectArray = parseRawTLEStringIntoTLEObjectArray(response.data);
         } catch (error) {
-        console.error("Error fetching launches", error);
+            // Use Example Data from JSON file in case of API error since no backup API exists.
+            // TODO - Notify the user that the backup example data is being used instead of the API
+            console.warn("Failed to load from API. Falling back to example data.", error);
+            parsedTLEObjectArray = parseRawTLEStringIntoTLEObjectArray(exampleDataFromJSON);
+        }
+        return parsedTLEObjectArray;
     }
-     */
-    // Example Data from JSON file
-    return parseRawTLEStringIntoTLEObjectArray(celestrak[0].data);
 };
 
 export const getSatellitePositionAtTime = (

--- a/src/backend/model/tests/launches_tests.ts
+++ b/src/backend/model/tests/launches_tests.ts
@@ -1,6 +1,7 @@
 import * as launchesC from "../../controllers/launches_controller.js";
 import * as launches from "../launches.js"
 import axios from "axios";
+
 // TODO - remove @ts-ignore and add proper typing
 /**
  * File for unit testing model in relation to api-1-feature-1/2.

--- a/src/backend/view/launches/launch_date_picker.tsx
+++ b/src/backend/view/launches/launch_date_picker.tsx
@@ -8,7 +8,6 @@ import type {
     newsOrLaunchDataSidePanelDataInterface
 } from "../../model/interfaces.ts";
 import {setLaunchData} from "../../model/launches.ts"
-import {loadNewsFeedData} from "../../model/events.ts";
 
 const APIErrorAlert = () => (
     // TODO - implement in the alert box section.
@@ -79,7 +78,6 @@ export const LaunchDateRangePicker = (
     // Create default data as soon as the component mounts.
     useEffect(() => {
         (async () => {
-            await loadNewsFeedData() // this should really be moved up, coz it doesn't belong in this function. actually, all the data-loading stuff should be refactored out of here
             seterrorLoadingLaunchDataFromAPI(false);
             setisloadingLaunchDataFromAPI(true);
             try {

--- a/src/backend/view/news-feed/news_feed.tsx
+++ b/src/backend/view/news-feed/news_feed.tsx
@@ -1,8 +1,24 @@
 import type {newsFeedDataInterface} from "../../model/interfaces.ts";
 import dayjs from "dayjs";
 import Image from "mui-image";
-import {LinearProgress, Link, Typography} from "@mui/material";
+import {Alert, LinearProgress, Link, Typography} from "@mui/material";
 import LinkIcon from "@mui/icons-material/Link";
+
+const NoNewsAlert = () => {
+    return (
+        <div style={{
+            display: "flex",
+            width: '100%',
+            height: "100%",
+            justifyContent: "center",
+            alignItems: "center"
+        }}>
+            <Alert severity="error" style={{width: "100%"}}>
+                News is currently unavailable - check in later.
+            </Alert>
+        </div>
+    );
+}
 
 const newsFeedItem = (content: newsFeedDataInterface) => {
     const formattedDate = dayjs(content.date).format('MMMM Do, YYYY');
@@ -78,9 +94,15 @@ export const NewsFeed = (content: newsFeedDataInterface[]) => {
         height: "100%",
         gap: "1rem"
     }}>
-        <Typography variant={"h5"} align={"center"}>News Feed</Typography>
-        {newsFeedItem(content[0])}
-        {newsFeedItem(content[1])}
-        {newsFeedItem(content[2])}
+        {content == undefined || content.length < 3 ? (
+            <NoNewsAlert/>
+        ) : (
+            <>
+                <Typography variant={"h5"} align={"center"}>News Feed</Typography>
+                {newsFeedItem(content[0])}
+                {newsFeedItem(content[1])}
+                {newsFeedItem(content[2])}
+            </>
+        )}
     </div>)
 }

--- a/src/backend/view/site_content.tsx
+++ b/src/backend/view/site_content.tsx
@@ -28,13 +28,13 @@ const SidePanelWithAnimatedTransitions = (
     useEffect(() => {
         (async () => {
             setPanelData({contentType: "loading", content: ""});
-            let newsFeedDataAsArray;
+            let newsFeedDataIntermediateArray;
             try {
-                // I have to use an intermediate variable or the code breaks - Anton TODO - look into this
-                newsFeedDataAsArray = await loadNewsFeedData()
-                setnewsFeedDataArray(await loadNewsFeedData());
+                // Use of an intermediate variable is required here, as the state doesn't get updated internally.
+                newsFeedDataIntermediateArray = await loadNewsFeedData()
+                setnewsFeedDataArray(newsFeedDataIntermediateArray);
             } finally {
-                setPanelData({contentType: "newsFeed", content: newsFeedDataAsArray});
+                setPanelData({contentType: "newsFeed", content: newsFeedDataIntermediateArray});
             }
         })();
     }, []);


### PR DESCRIPTION
- Added real API endpoints for both API 1 and API 2
- Added fallback code so that if the real API endpoints error out (probably due to too many requests), the site falls back to the dev endpoints w/ stale data (API 1 / LL2) or example data stored in JSON (API 2 / CELESTRAK) as no dev API is available
- Added .env file to easily switch between using the real APIs or skipping them to just use the dev endpoints/example JSON.

*Note: Pushing the .env file was intentional as we have no private API keys.*